### PR TITLE
#78: fix: removed refs to node_modules

### DIFF
--- a/views/header.ejs
+++ b/views/header.ejs
@@ -12,14 +12,5 @@
     <link rel="stylesheet" href="<%= documentPath %><%= customThemeCss %>">
     <% } %>
     <link rel="stylesheet" href="<%= absolutePath %><%= highlightJsThemeCss %>">
-
-    <script>
-      var link = document.createElement( 'link' );
-      link.rel = 'stylesheet';
-      link.type = 'text/x-scss';
-      link.href = window.location.search.match( /print-pdf/gi ) ? '<%= absolutePath %>node_modules/reveal.js/css/print/pdf.scss' : '<%= absolutePath %>node_modules/reveal.js/css/print/paper.scss';
-      document.getElementsByTagName( 'head' )[0].appendChild( link );
-    </script>
-
     <%- include('asciidoc-styles'); -%>
   </head>


### PR DESCRIPTION
these SCSS files are templates and should not be used directly. all files seems are compiled already